### PR TITLE
Follow pubspec description length rules

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: hf_retry
-description: A plugin to enhance user experience during network downtime.
+description: A package to enhance user experience during network downtime.
 version: 0.0.1
 homepage: https://github.com/hireflutter-dev/hf-retry
 


### PR DESCRIPTION
1. As mentioned in this [Stack Overflow post](https://stackoverflow.com/a/54733856/11626847), a plugin implements native functionality. So it makes more sense to use the term 'package' here.
2. pub.dev requires the description to be at least 60 characters. This fix also awards 10 pub points